### PR TITLE
Remove PackageDependency Name="Microsoft.NET.CoreRuntime.1.1"

### DIFF
--- a/Samples/Win32/SampleCppApp.Package/Package.appxmanifest
+++ b/Samples/Win32/SampleCppApp.Package/Package.appxmanifest
@@ -19,7 +19,6 @@
 
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14393.0" MaxVersionTested="10.0.14393.0" />
-    <PackageDependency Name="Microsoft.NET.CoreRuntime.1.1" MinVersion="1.1.27004.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
   </Dependencies>
 
   <Resources>


### PR DESCRIPTION
On my platform, if it include this dependency, it will not compiled.