### PR TITLE
Fix native and Contoso sample build on 19041 SDK

### DIFF
--- a/Samples/Native/MyApp/App.base.h
+++ b/Samples/Native/MyApp/App.base.h
@@ -24,12 +24,12 @@ namespace winrt::MyApp::implementation
 
     private:
         bool _contentLoaded{ false };
-        std::shared_ptr<XamlMetaDataProvider> _appProvider;
-        std::shared_ptr<XamlMetaDataProvider> AppProvider()
+        ::winrt::com_ptr<XamlMetaDataProvider> _appProvider;
+        ::winrt::com_ptr<XamlMetaDataProvider> AppProvider()
         {
             if (!_appProvider)
             {
-                _appProvider = std::make_shared<XamlMetaDataProvider>();
+                _appProvider = ::winrt::make_self<XamlMetaDataProvider>();
             }
             return _appProvider;
         }

--- a/Standalone_Samples/Contoso/Xaml/App.base.h
+++ b/Standalone_Samples/Contoso/Xaml/App.base.h
@@ -24,12 +24,12 @@ namespace winrt::MyApp::implementation
 
     private:
         bool _contentLoaded{ false };
-        std::shared_ptr<XamlMetaDataProvider> _appProvider;
-        std::shared_ptr<XamlMetaDataProvider> AppProvider()
+        ::winrt::com_ptr<XamlMetaDataProvider> _appProvider;
+        ::winrt::com_ptr<XamlMetaDataProvider> AppProvider()
         {
             if (!_appProvider)
             {
-                _appProvider = std::make_shared<XamlMetaDataProvider>();
+                _appProvider = ::winrt::make_self<XamlMetaDataProvider>();
             }
             return _appProvider;
         }

--- a/Standalone_Samples/CppWinRT_Basic_Win32App/ReadMe.md
+++ b/Standalone_Samples/CppWinRT_Basic_Win32App/ReadMe.md
@@ -1,1 +1,1 @@
-# [Native C++/WinRT Win32 Sample](/Samples/Win32/ReadMe.md)
+# [Native C++/WinRT Win32 Sample](/Samples/Win32/ReadMe.md)  


### PR DESCRIPTION
Fixes a build issue when the project was upgraded to 19041, build also still works when using the 18362 SDK.