### PR TITLE
Fix CI error

### DIFF
--- a/.github/workflows/CPP-CI.yml
+++ b/.github/workflows/CPP-CI.yml
@@ -67,12 +67,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Install the .NET Core workload
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.201
-
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/Contoso-CI.yml
+++ b/.github/workflows/Contoso-CI.yml
@@ -67,12 +67,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Install the .NET Core workload
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.201
-
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/WPF-CI.yml
+++ b/.github/workflows/WPF-CI.yml
@@ -67,12 +67,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Install the .NET Core workload
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.201
-
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/WinForms-CI.yml
+++ b/.github/workflows/WinForms-CI.yml
@@ -67,12 +67,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    # Install the .NET Core workload
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.201
-
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@v1.0.2


### PR DESCRIPTION
I have removed dotnet install task and seems that it works.
The 3.1.201 version is already installed on image and somehow this fact and the fact that you use msbuild and its environment somehow broke it for now :( 
We have tried to use older version of actions/setup-dotnet@v1 task(v1.7.2), but no luck here. I suggest to workaround this problem until we investigate the root cause.